### PR TITLE
support Redission jsonyaml-file-based-configuration

### DIFF
--- a/src/zoo/websocket/starter/src/main/java/org/tio/websocket/starter/RedisInitializer.java
+++ b/src/zoo/websocket/starter/src/main/java/org/tio/websocket/starter/RedisInitializer.java
@@ -5,17 +5,28 @@ import org.redisson.api.RedissonClient;
 import org.redisson.codec.FstCodec;
 import org.redisson.config.Config;
 import org.redisson.config.SingleServerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
 
 /**
  * @author fanpan26
  * */
 public final class RedisInitializer {
 
+    private static final Logger logger = LoggerFactory.getLogger(RedisInitializer.class);
+
     private RedissonClient redissonClient;
+    private ApplicationContext applicationContext;
     private TioWebSocketServerClusterProperties.RedisConfig redisConfig;
 
-    public RedisInitializer(TioWebSocketServerClusterProperties.RedisConfig redisConfig) {
+    public RedisInitializer(TioWebSocketServerClusterProperties.RedisConfig redisConfig, ApplicationContext applicationContext) {
         this.redisConfig = redisConfig;
+        this.applicationContext = applicationContext;
 
         initRedis();
     }
@@ -24,21 +35,45 @@ public final class RedisInitializer {
         return redissonClient;
     }
 
-    private void initRedis() {
-        Config config = new Config();
+    private URL getFileUri(String fileName) {
+        Map<String, Object> annotationMap = applicationContext.getBeansWithAnnotation(EnableTioWebSocketServer.class);
+        Class applicationClazz = annotationMap.entrySet().iterator().next().getValue().getClass();
+        ClassLoader classLoader = applicationClazz.getClassLoader();
+        return classLoader.getResource(fileName);
+    }
 
+    private void initRedis() {
+        Config config = getConfigByFile();
+        if (config == null) {
+            config = getSingleServerConfig();
+        }
+        redissonClient = Redisson.create(config);
+    }
+    private Config getConfigByFile() {
+        try {
+            if (redisConfig.isJSONConfig()) {
+                return Config.fromJSON(getFileUri(redisConfig.getConfigPath()));
+            } else if (redisConfig.isYAMLConfig()) {
+                return Config.fromYAML(getFileUri(redisConfig.getConfigPath()));
+            }
+        } catch (IOException e) {
+            logger.error("init with file config error", e);
+        }
+        return null;
+    }
+    private Config getSingleServerConfig() {
+        Config config = new Config();
         String address = redisConfig.toString();
         SingleServerConfig singleServerConfig = config.useSingleServer()
                 .setAddress(address)
                 .setConnectionPoolSize(redisConfig.getPoolSize())
                 .setConnectionMinimumIdleSize(redisConfig.getMinimumIdleSize());
-
         if (redisConfig.hasPassword()) {
             singleServerConfig.setPassword(redisConfig.getPassword());
         }
         config.setCodec(new FstCodec());
         //默认情况下，看门狗的检查锁的超时时间是30秒钟
         config.setLockWatchdogTimeout(1000 * 30);
-        redissonClient = Redisson.create(config);
+        return config;
     }
 }

--- a/src/zoo/websocket/starter/src/main/java/org/tio/websocket/starter/TioWebSocketServerAutoConfiguration.java
+++ b/src/zoo/websocket/starter/src/main/java/org/tio/websocket/starter/TioWebSocketServerAutoConfiguration.java
@@ -88,8 +88,8 @@ public class TioWebSocketServerAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty(value = "tio.websocket.cluster.enabled",havingValue = "true",matchIfMissing = true)
-    public RedisInitializer redisInitializer(){
-        return new RedisInitializer(redisConfig);
+    public RedisInitializer redisInitializer(ApplicationContext applicationContext) {
+        return new RedisInitializer(redisConfig, applicationContext);
     }
 
 

--- a/src/zoo/websocket/starter/src/main/java/org/tio/websocket/starter/TioWebSocketServerClusterProperties.java
+++ b/src/zoo/websocket/starter/src/main/java/org/tio/websocket/starter/TioWebSocketServerClusterProperties.java
@@ -88,6 +88,37 @@ public class TioWebSocketServerClusterProperties {
 
     @ConfigurationProperties("tio.websocket.cluster.redis")
     public static class RedisConfig {
+
+        public boolean useConfigFile(){
+            if (StrUtil.isBlank(configPath)){
+                return false;
+            }
+            return true;
+        }
+
+        public boolean isYAMLConfig() {
+            if (useConfigFile()) {
+                return configPath.toLowerCase().endsWith("yaml");
+            }
+            return false;
+        }
+
+        public boolean isJSONConfig() {
+            if (useConfigFile()) {
+                return configPath.toLowerCase().endsWith("json");
+            }
+            return false;
+        }
+
+        public String getConfigPath() {
+            return configPath;
+        }
+
+        public void setConfigPath(String configPath) {
+            this.configPath = configPath;
+        }
+
+        private String configPath;
         private String ip = "127.0.0.1";
 
         public String getIp() {


### PR DESCRIPTION
doc：[Redission configuration](https://github.com/redisson/redisson/wiki/2.-Configuration#221-jsonyaml-file-based-configuration)

web client config：

```
 redis:
         //json  or yaml
        config-path: redis-cluster-config.yaml
```

