### PR TITLE
添加 tio-core 组件的 spring-boot-starter 实现

### DIFF
--- a/src/zoo/spring-boot/tio-core/pom.xml
+++ b/src/zoo/spring-boot/tio-core/pom.xml
@@ -30,6 +30,12 @@
             <artifactId>tio-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/RedisInitializer.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/RedisInitializer.java
@@ -1,0 +1,45 @@
+package org.tio.core.starter;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.codec.FstCodec;
+import org.redisson.config.Config;
+import org.redisson.config.SingleServerConfig;
+
+/**
+ * @author yangjian
+ * @author fanpan26
+ * */
+public final class RedisInitializer {
+
+    private RedissonClient redissonClient;
+    private TioServerClusterProperties.RedisConfig redisConfig;
+
+    public RedisInitializer(TioServerClusterProperties.RedisConfig redisConfig) {
+        this.redisConfig = redisConfig;
+
+        initRedis();
+    }
+
+    public RedissonClient getRedissonClient() {
+        return redissonClient;
+    }
+
+    private void initRedis() {
+        Config config = new Config();
+
+        String address = redisConfig.toString();
+        SingleServerConfig singleServerConfig = config.useSingleServer()
+                .setAddress(address)
+                .setConnectionPoolSize(redisConfig.getPoolSize())
+                .setConnectionMinimumIdleSize(redisConfig.getMinimumIdleSize());
+
+        if (redisConfig.hasPassword()) {
+            singleServerConfig.setPassword(redisConfig.getPassword());
+        }
+        config.setCodec(new FstCodec());
+        //默认情况下，看门狗的检查锁的超时时间是30秒钟
+        config.setLockWatchdogTimeout(1000 * 30);
+        redissonClient = Redisson.create(config);
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioMsgHandlerNotFoundException.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioMsgHandlerNotFoundException.java
@@ -1,0 +1,10 @@
+package org.tio.core.starter;
+
+/**
+ * @author fyp
+ */
+public class TioMsgHandlerNotFoundException extends RuntimeException {
+    public TioMsgHandlerNotFoundException() {
+        super();
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerAutoConfiguration.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerAutoConfiguration.java
@@ -1,0 +1,101 @@
+package org.tio.core.starter;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.tio.cluster.redisson.RedissonTioClusterTopic;
+import org.tio.core.intf.GroupListener;
+import org.tio.core.stat.IpStatListener;
+import org.tio.server.ServerGroupContext;
+import org.tio.server.intf.ServerAioHandler;
+import org.tio.server.intf.ServerAioListener;
+
+
+/**
+ * @author fanpan26
+ * @author yangjian
+ * */
+@Configuration
+@Import(TioServerInitializerConfiguration.class)
+@ConditionalOnBean(TioServerMarkerConfiguration.Marker.class)
+@EnableConfigurationProperties({
+        TioServerProperties.class,
+        TioServerClusterProperties.class,
+        TioServerClusterProperties.RedisConfig.class,
+        TioServerSslProperties.class})
+public class TioServerAutoConfiguration {
+
+    /**
+     *  cluster topic channel
+     * */
+    private static final String CLUSTER_TOPIC_CHANNEL = "tio_server_spring_boot_starter";
+
+    @Autowired(required = false)
+    private ServerAioHandler serverAioHandler;
+
+    @Autowired(required = false)
+    private IpStatListener ipStatListener;
+
+    @Autowired(required = false)
+    private GroupListener groupListener;
+
+    @Autowired(required = false)
+    private ServerAioListener serverAioListener;
+
+    @Autowired
+    private TioServerClusterProperties clusterProperties;
+
+    @Autowired
+    private TioServerClusterProperties.RedisConfig redisConfig;
+
+    @Autowired
+    private TioServerProperties serverProperties;
+
+    @Autowired
+    private TioServerSslProperties serverSslProperties;
+
+    @Autowired(required = false)
+    private RedissonTioClusterTopic redissonTioClusterTopic;
+
+    /**
+     * Tio Server bootstrap
+     * */
+    @Bean
+    public TioServerBootstrap webSocketServerBootstrap() {
+        return new TioServerBootstrap(
+                serverProperties,
+                clusterProperties,
+                serverSslProperties,
+                redissonTioClusterTopic,
+                ipStatListener,
+                groupListener,
+                serverAioHandler,
+                serverAioListener);
+    }
+
+    @Bean
+    public ServerGroupContext serverGroupContext(TioServerBootstrap bootstrap){
+        return bootstrap.getServerGroupContext();
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "tio.core.cluster.enabled",havingValue = "true",matchIfMissing = true)
+    public RedisInitializer redisInitializer(){
+        return new RedisInitializer(redisConfig);
+    }
+
+
+    /**
+     *  RedissonTioClusterTopic  with  RedisInitializer
+     * */
+    @Bean
+    @ConditionalOnBean(RedisInitializer.class)
+    public RedissonTioClusterTopic redissonTioClusterTopic(RedisInitializer redisInitializer) {
+        return new RedissonTioClusterTopic(CLUSTER_TOPIC_CHANNEL,redisInitializer.getRedissonClient());
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerBootstrap.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerBootstrap.java
@@ -1,0 +1,145 @@
+package org.tio.core.starter;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tio.cluster.TioClusterConfig;
+import org.tio.cluster.redisson.RedissonTioClusterTopic;
+import org.tio.core.intf.GroupListener;
+import org.tio.core.stat.IpStatListener;
+import org.tio.server.ServerGroupContext;
+import org.tio.server.TioServer;
+import org.tio.server.intf.ServerAioHandler;
+import org.tio.server.intf.ServerAioListener;
+
+import java.io.IOException;
+
+/**
+ * @author fanpan26
+ * @author yangjian
+ * */
+public final class TioServerBootstrap {
+
+    private static final Logger logger = LoggerFactory.getLogger(TioServerBootstrap.class);
+
+    private static final String GROUP_CONTEXT_NAME = "tio-server-spring-boot-starter";
+
+    private TioServerProperties serverProperties;
+    private TioServerClusterProperties clusterProperties;
+    private TioServerSslProperties serverSslProperties;
+    private RedissonTioClusterTopic redissonTioClusterTopic;
+    private TioClusterConfig clusterConfig;
+    private TioServer tioServer;
+    private ServerGroupContext serverGroupContext;
+    private ServerAioHandler serverAioHandler;
+    private IpStatListener ipStatListener;
+    private GroupListener groupListener;
+    private ServerAioListener serverAioListener;
+
+    public TioServerBootstrap(TioServerProperties serverProperties,
+                              TioServerClusterProperties clusterProperties,
+                              TioServerSslProperties serverSslProperties,
+                              RedissonTioClusterTopic redissonTioClusterTopic,
+                              IpStatListener ipStatListener,
+                              GroupListener groupListener,
+                              ServerAioHandler serverAioHandler,
+                              ServerAioListener serverAioListener) {
+        this.serverProperties = serverProperties;
+        this.clusterProperties = clusterProperties;
+        this.serverSslProperties = serverSslProperties;
+
+        logger.debug(serverSslProperties.toString());
+        if (redissonTioClusterTopic == null) {
+            logger.info("cluster mod closed");
+        }
+        this.redissonTioClusterTopic = redissonTioClusterTopic;
+        this.ipStatListener = ipStatListener;
+        this.groupListener = groupListener;
+        this.serverAioListener = serverAioListener;
+        this.serverAioHandler = serverAioHandler;
+        afterSetProperties();
+    }
+
+    private void afterSetProperties(){
+        if (this.serverAioHandler == null) {
+            throw new TioMsgHandlerNotFoundException();
+        }
+        if (this.ipStatListener == null){
+            logger.warn("no bean type of IpStatListener found");
+        }
+        if (this.groupListener == null){
+            logger.warn("no bean type of GroupListener found");
+        }
+    }
+
+
+    public ServerGroupContext getServerGroupContext() {
+        return serverGroupContext;
+    }
+
+    public void contextInitialized() {
+        logger.info("initialize tio websocket server");
+        try {
+            initTioServerConfig();
+            initTioServerGroupContext();
+            initTioServer();
+            start();
+        }
+        catch (Throwable e) {
+            logger.error("Cannot bootstrap tio server :", e);
+            throw new RuntimeException("Cannot bootstrap tio server :", e);
+        }
+    }
+
+    private void initTioServerConfig() {
+
+        if (redissonTioClusterTopic != null && clusterProperties.isEnabled()) {
+            this.clusterConfig = new TioClusterConfig(redissonTioClusterTopic);
+            this.clusterConfig.setCluster4all(clusterProperties.isAll());
+            this.clusterConfig.setCluster4bsId(true);
+            this.clusterConfig.setCluster4channelId(clusterProperties.isChannel());
+            this.clusterConfig.setCluster4group(clusterProperties.isGroup());
+            this.clusterConfig.setCluster4ip(clusterProperties.isIp());
+            this.clusterConfig.setCluster4user(clusterProperties.isUser());
+        }
+    }
+
+    private void initTioServer()
+    {
+        this.tioServer = new TioServer(serverGroupContext);
+    }
+
+    private void initTioServerGroupContext()
+    {
+        serverGroupContext = new ServerGroupContext(GROUP_CONTEXT_NAME, serverAioHandler, serverAioListener);
+        if (ipStatListener != null) {
+            serverGroupContext.setIpStatListener(ipStatListener);
+        }
+        if(serverAioListener != null) {
+            serverGroupContext.setServerAioListener(serverAioListener);
+        }
+        if (groupListener != null) {
+            serverGroupContext.setGroupListener(groupListener);
+        }
+        if (serverProperties.getHeartbeatTimeout() > 0) {
+            serverGroupContext.setHeartbeatTimeout(serverProperties.getHeartbeatTimeout());
+        }
+        //cluster config
+        if (clusterConfig != null) {
+            serverGroupContext.setTioClusterConfig(clusterConfig);
+        }
+        //ssl config
+        if (serverSslProperties.isEnabled()){
+            try {
+                serverGroupContext.useSsl(serverSslProperties.getKeyStore(), serverSslProperties.getTrustStore(), serverSslProperties.getPassword());
+            }catch (Exception e){
+                //catch and log
+                logger.error("init ssl config error",e);
+            }
+        }
+    }
+
+    private void start() throws IOException {
+        tioServer.start(serverProperties.getIp(), serverProperties.getPort());
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerClusterProperties.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerClusterProperties.java
@@ -1,0 +1,146 @@
+package org.tio.core.starter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.tio.utils.hutool.StrUtil;
+
+/**
+ * Tio 集群配置
+ * @author yangjian
+ * @author fanpan26
+ * */
+@ConfigurationProperties(prefix = "tio.core.cluster")
+public class TioServerClusterProperties {
+
+    private final static String REDIS_CONFIG_PREFIX = "tio.core.cluster.redis";
+    /**
+     * 是否开启集群 默认为 false
+     * */
+    private boolean enabled = false;
+    /**
+     * 群组是否集群（同一个群组是否会分布在不同的机器上），false:不集群，默认不集群
+     */
+    private boolean	group = false;
+    /**
+     * 用户是否集群（同一个用户是否会分布在不同的机器上），false:不集群，默认集群
+     */
+    private boolean	user = true;
+    /**
+     * ip是否集群（同一个ip是否会分布在不同的机器上），false:不集群，默认集群
+     */
+    private boolean	ip = true;
+    /**
+     * id是否集群（在A机器上的客户端是否可以通过channelId发消息给B机器上的客户端），false:不集群，默认集群<br>
+     */
+    private boolean	channel	= true;
+    /**
+     * 所有连接是否集群（同一个ip是否会分布在不同的机器上），false:不集群，默认集群
+     */
+    private boolean	all = true;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isGroup() {
+        return group;
+    }
+
+    public void setGroup(boolean group) {
+        this.group = group;
+    }
+
+    public boolean isUser() {
+        return user;
+    }
+
+    public void setUser(boolean user) {
+        this.user = user;
+    }
+
+    public boolean isIp() {
+        return ip;
+    }
+
+    public void setIp(boolean ip) {
+        this.ip = ip;
+    }
+
+    public boolean isChannel() {
+        return channel;
+    }
+
+    public void setChannel(boolean channel) {
+        this.channel = channel;
+    }
+
+    public boolean isAll() {
+        return all;
+    }
+
+    public void setAll(boolean bll) {
+        this.all = bll;
+    }
+
+    @ConfigurationProperties(REDIS_CONFIG_PREFIX)
+    public static class RedisConfig {
+
+        private String ip = "127.0.0.1";
+        private Integer port = 6379;
+        private String password;
+        private Integer poolSize = 32;
+        private Integer minimumIdleSize=16;
+
+        public String getIp() {
+            return ip;
+        }
+
+        public void setIp(String ip) {
+            this.ip = ip;
+        }
+
+        public Integer getPort() {
+            return port;
+        }
+
+        public void setPort(Integer port) {
+            this.port = port;
+        }
+
+        public boolean hasPassword(){
+            return StrUtil.isNotBlank(getPassword());
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public Integer getPoolSize() {
+            return poolSize;
+        }
+
+        public void setPoolSize(Integer poolSize) {
+            this.poolSize = poolSize;
+        }
+
+        public Integer getMinimumIdleSize() {
+            return minimumIdleSize;
+        }
+
+        public void setMinimumIdleSize(Integer minimumIdleSize) {
+            this.minimumIdleSize = minimumIdleSize;
+        }
+
+        @Override
+        public String toString() {
+            return "redis://" + getIp() + ":" + getPort();
+        }
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerDefaultUuid.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerDefaultUuid.java
@@ -1,0 +1,25 @@
+package org.tio.core.starter;
+
+import org.tio.core.intf.TioUuid;
+import org.tio.utils.hutool.Snowflake;
+
+/**
+ * @author fanpan26
+ * */
+public class TioServerDefaultUuid implements TioUuid {
+    private Snowflake snowflake;
+
+
+    public TioServerDefaultUuid(long workerId, long dataCenterId) {
+        snowflake = new Snowflake(workerId, dataCenterId);
+    }
+
+    /**
+     * @return new uuid
+     * @author tanyaowu
+     */
+    @Override
+    public String uuid() {
+        return snowflake.nextId() + "";
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerInitializerConfiguration.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerInitializerConfiguration.java
@@ -1,0 +1,59 @@
+package org.tio.core.starter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+/**
+ * @author fanpan26
+ * */
+@Configuration
+public class TioServerInitializerConfiguration
+        implements SmartLifecycle, Ordered {
+
+    private int order = 1;
+    private boolean running = false;
+
+    @Autowired
+    private TioServerBootstrap tioServerBootstrap;
+
+
+    @Override
+    public void start() {
+        new Thread(() -> {
+            tioServerBootstrap.contextInitialized();
+            running = true;
+        }).start();
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public int getPhase() {
+        return 0;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
+
+    @Override
+    public void stop(Runnable runnable) {
+
+    }
+
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerMarkerConfiguration.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerMarkerConfiguration.java
@@ -1,0 +1,22 @@
+package org.tio.core.starter;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 负责添加一个标记，表示 Tio Server 已经启用，防止重复启用
+ * {@link TioServerAutoConfiguration}
+ * @author yangjian
+ * @author fanpan26
+ * */
+@Configuration
+public class TioServerMarkerConfiguration {
+
+    @Bean
+    public Marker tioWebSocketServerMarkBean() {
+        return new Marker();
+    }
+
+    class Marker {
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerProperties.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerProperties.java
@@ -1,0 +1,47 @@
+package org.tio.core.starter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author yangjian
+ * */
+@ConfigurationProperties(prefix = "tio.core.server")
+public class TioServerProperties {
+
+    /**
+     * 服务绑定的 IP 地址，默认不绑定
+     */
+    private String ip = null;
+    /**
+     * 服务绑定的端口
+     */
+    private int port = 6789;
+    /**
+     * 心跳超时时间，超时会自动关闭连接
+     */
+    private int heartbeatTimeout = 5000;
+
+    public String getIp() {
+        return ip;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public int getHeartbeatTimeout() {
+        return heartbeatTimeout;
+    }
+
+    public void setHeartbeatTimeout(int heartbeatTimeout) {
+        this.heartbeatTimeout = heartbeatTimeout;
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerSslProperties.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/TioServerSslProperties.java
@@ -1,0 +1,60 @@
+package org.tio.core.starter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * SSL 连接配置
+ * @author yangjian
+ */
+@ConfigurationProperties(prefix = "tio.core.ssl")
+public class TioServerSslProperties {
+
+    /**
+     * 是否开启 SSL 连接，默认不开启
+     */
+    private boolean enabled = false;
+    /**
+     * ssl keystore 文件地址
+     */
+    private String keyStore;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getKeyStore() {
+        return keyStore;
+    }
+
+    public void setKeyStore(String keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    public String getTrustStore() {
+        return trustStore;
+    }
+
+    public void setTrustStore(String trustStore) {
+        this.trustStore = trustStore;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    private String trustStore;
+    private String password;
+
+    @Override
+    public String toString() {
+        return "keyStore:" + keyStore + "\n trustStore:" + trustStore;
+    }
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/EnableTioServerServer.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/EnableTioServerServer.java
@@ -1,0 +1,19 @@
+package org.tio.core.starter.annotation;
+
+import org.tio.core.starter.TioServerAutoConfiguration;
+import org.tio.core.starter.TioServerMarkerConfiguration;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+/**
+ * 此注解用于启用 Tio Server 服务，有关配置请参考 {@link TioServerAutoConfiguration}
+ * @author yangjian
+ * @author fanpan26
+ * */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(TioServerMarkerConfiguration.class)
+public @interface EnableTioServerServer {
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerAioListener.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerAioListener.java
@@ -1,0 +1,11 @@
+package org.tio.core.starter.annotation;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Tio Server 消息监听器注解，用来创建消息监听器实例
+ * @author yangjian
+ */
+@Service
+public @interface TioServerAioListener  {
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerGroupListener.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerGroupListener.java
@@ -1,0 +1,11 @@
+package org.tio.core.starter.annotation;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Tio Server group 监听器注解
+ * @author yangjian
+ */
+@Service
+public @interface TioServerGroupListener {
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerIpStatListener.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerIpStatListener.java
@@ -1,0 +1,11 @@
+package org.tio.core.starter.annotation;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Tio Server IP 统计监听器注解
+ * @author yangjian
+ */
+@Service
+public @interface TioServerIpStatListener {
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerMsgHandler.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/annotation/TioServerMsgHandler.java
@@ -1,0 +1,12 @@
+package org.tio.core.starter.annotation;
+
+import org.tio.core.starter.handler.TioServerAioHandler;
+import org.springframework.stereotype.Service;
+
+/**
+ * Tio Server message handler 注解，用来创建 {@link TioServerAioHandler}
+ * @author yangjian
+ * */
+@Service
+public @interface TioServerMsgHandler {
+}

--- a/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/handler/TioServerAioHandler.java
+++ b/src/zoo/spring-boot/tio-core/src/main/java/org/tio/core/starter/handler/TioServerAioHandler.java
@@ -1,0 +1,10 @@
+package org.tio.core.starter.handler;
+
+import org.tio.server.intf.ServerAioHandler;
+
+/**
+ * Tio 服务端消息处理 handler 接口
+ * @author yangjian
+ * */
+public interface TioServerAioHandler extends ServerAioHandler {
+}

--- a/src/zoo/spring-boot/tio-core/src/main/resources/META-INF/spring.factories
+++ b/src/zoo/spring-boot/tio-core/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.tio.core.starter.TioServerAutoConfiguration


### PR DESCRIPTION
实现了 tio-core 的 spring-boot-starter , 已经过测试，测试项目地址为：

https://gitee.com/blackfox/tio-starter/tree/master/spring-boot-starter-demo

clone 下来直接运行 Application 即可。