### PR TITLE
增加Redis客户端创建方式

### DIFF
--- a/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/RedisInitializer.java
+++ b/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/RedisInitializer.java
@@ -1,17 +1,19 @@
 package org.tio.websocket.starter;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.codec.FstCodec;
+import org.redisson.config.ClusterServersConfig;
 import org.redisson.config.Config;
 import org.redisson.config.SingleServerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.Map;
 
 /**
  * @author fanpan26
@@ -43,6 +45,23 @@ public final class RedisInitializer {
     }
 
     private void initRedis() {
+    	
+    	// add by kuangyoubo 20190621
+    	if( redisConfig.useInjectRedissonClient() ) {
+    		logger.info("Get the RedissonClient through injection, Bean name is \"{}\"", redisConfig.getClientBeanName());
+    		
+    		try {
+    			redissonClient = applicationContext.getBean(redisConfig.getClientBeanName(), RedissonClient.class);
+    		
+    			return;
+    		}
+    		catch( BeansException e ) {
+
+        		logger.warn("RedissonClient is not found, Recreate RedissonClient on configuration information.");
+        		
+    		}
+    	}
+    	
         Config config = getConfigByFile();
         if (config == null) {
             config = getSingleServerConfig();
@@ -68,6 +87,24 @@ public final class RedisInitializer {
                 .setAddress(address)
                 .setConnectionPoolSize(redisConfig.getPoolSize())
                 .setConnectionMinimumIdleSize(redisConfig.getMinimumIdleSize());
+        if (redisConfig.hasPassword()) {
+            singleServerConfig.setPassword(redisConfig.getPassword());
+        }
+        config.setCodec(new FstCodec());
+        //默认情况下，看门狗的检查锁的超时时间是30秒钟
+        config.setLockWatchdogTimeout(1000 * 30);
+        return config;
+    }
+    
+    private Config getClusterServerConfig() {
+        Config config = new Config();
+        String address = redisConfig.toString();
+        ClusterServersConfig singleServerConfig = config.useClusterServers();
+        
+        /**        .setAddress(address)
+                .setConnectionPoolSize(redisConfig.getPoolSize())
+                .setConnectionMinimumIdleSize(redisConfig.getMinimumIdleSize());
+                **/
         if (redisConfig.hasPassword()) {
             singleServerConfig.setPassword(redisConfig.getPassword());
         }

--- a/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerAutoConfiguration.java
+++ b/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerAutoConfiguration.java
@@ -86,7 +86,12 @@ public class TioWebSocketServerAutoConfiguration {
         return bootstrap.getServerGroupContext();
     }
 
-    @Bean
+    /**
+     * 初始化RedisInitializer
+     * @param applicationContext
+     * @return
+     */
+    @Bean(destroyMethod="shutdown")
     @ConditionalOnProperty(value = "tio.websocket.cluster.enabled",havingValue = "true",matchIfMissing = true)
     public RedisInitializer redisInitializer(ApplicationContext applicationContext) {
         return new RedisInitializer(redisConfig, applicationContext);

--- a/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerClusterProperties.java
+++ b/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerClusterProperties.java
@@ -1,13 +1,13 @@
 package org.tio.websocket.starter;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.tio.utils.hutool.StrUtil;
-
 import static org.tio.websocket.starter.TioWebSocketServerClusterProperties.PREFIX;
 
 import org.redisson.config.ClusterServersConfig;
+import org.redisson.config.Config;
 import org.redisson.config.SentinelServersConfig;
-import org.redisson.config.SingleServerConfig;
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.tio.utils.hutool.StrUtil;
 
 /**
  * @author fanpan26
@@ -93,19 +93,21 @@ public class TioWebSocketServerClusterProperties {
     @ConfigurationProperties("tio.websocket.cluster.redis")
     public static class RedisConfig {
     	
+    	private final String SENTINEL = "sentinel";
+    	private final String CLUSTER = "cluster";
+    	
     	/**
     	 * single 单机 cluster 集群 sentinel 哨兵
+    	 * single 已经实现了，就不在这里实现
     	 */
     	private String mode;
 
     	private ClusterServersConfig cluster;
 
-    	private SingleServerConfig single;
-
     	private SentinelServersConfig sentinel;
     	
     	/**
-    	 * 根据beanName直接注入redissonClient，优先级大于配置参数
+    	 * 根据beanName直接注入redissonClient，优先级大于配置文件 -》 参数配置
     	 * @author kuangyoubo
     	 * @date 2019-06-21 12:15
     	 */
@@ -125,8 +127,57 @@ public class TioWebSocketServerClusterProperties {
             }
 			return true;
 		}
-		//add end 20190621
 
+		public String getMode() {
+			return mode;
+		}
+
+		public void setMode(String mode) {
+			this.mode = mode;
+		}
+		
+		public boolean useConfigParameter() {
+			if (StrUtil.isBlank(this.mode)){
+                return false;
+            }
+			return true;
+		}
+
+		public Config getClusterOrSentinelConfig() {
+			Config config = new Config();
+			
+			if( CLUSTER.equals(mode) ) {
+				ClusterServersConfig clusterServersConfig = config.useClusterServers();
+				
+				BeanUtils.copyProperties(this.cluster, clusterServersConfig, ClusterServersConfig.class);
+				
+				this.cluster.getNodeAddresses().parallelStream().forEach( node -> {
+					clusterServersConfig.addNodeAddress( node.toString() );
+				});
+			}
+			else if( SENTINEL.equals(mode) ) {
+				SentinelServersConfig sentinelServersConfig = config.useSentinelServers();
+				
+				BeanUtils.copyProperties(this.sentinel, sentinelServersConfig, SentinelServersConfig.class);
+				
+				this.sentinel.getSentinelAddresses().parallelStream().forEach( node -> {
+					sentinelServersConfig.addSentinelAddress( node.toString() );
+				});
+				
+			}
+			
+			return config;
+		}
+
+		public void setCluster(ClusterServersConfig cluster) {
+			this.cluster = cluster;
+		}
+
+		public void setSentinel(SentinelServersConfig sentinel) {
+			this.sentinel = sentinel;
+		}
+		//add end 20190621
+		
 		public boolean useConfigFile(){
             if (StrUtil.isBlank(configPath)){
                 return false;

--- a/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerClusterProperties.java
+++ b/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerClusterProperties.java
@@ -5,6 +5,10 @@ import org.tio.utils.hutool.StrUtil;
 
 import static org.tio.websocket.starter.TioWebSocketServerClusterProperties.PREFIX;
 
+import org.redisson.config.ClusterServersConfig;
+import org.redisson.config.SentinelServersConfig;
+import org.redisson.config.SingleServerConfig;
+
 /**
  * @author fanpan26
  * */
@@ -88,8 +92,42 @@ public class TioWebSocketServerClusterProperties {
 
     @ConfigurationProperties("tio.websocket.cluster.redis")
     public static class RedisConfig {
+    	
+    	/**
+    	 * single 单机 cluster 集群 sentinel 哨兵
+    	 */
+    	private String mode;
 
-        public boolean useConfigFile(){
+    	private ClusterServersConfig cluster;
+
+    	private SingleServerConfig single;
+
+    	private SentinelServersConfig sentinel;
+    	
+    	/**
+    	 * 根据beanName直接注入redissonClient，优先级大于配置参数
+    	 * @author kuangyoubo
+    	 * @date 2019-06-21 12:15
+    	 */
+    	private String clientBeanName;
+
+        public String getClientBeanName() {
+			return clientBeanName;
+		}
+
+		public void setClientBeanName(String clientBeanName) {
+			this.clientBeanName = clientBeanName;
+		}
+		
+		public boolean useInjectRedissonClient() {
+			if (StrUtil.isBlank(clientBeanName)){
+                return false;
+            }
+			return true;
+		}
+		//add end 20190621
+
+		public boolean useConfigFile(){
             if (StrUtil.isBlank(configPath)){
                 return false;
             }


### PR DESCRIPTION
1、通过Bean Name获取Redis客户端
2、根据mode来区分使用cluster还是sentinel配置

# 配置如下
      redis:
        client-bean-name: redis客户端bean的名字
        mode: cluster # cluster 集群 sentinel 哨兵
        cluster:
          nodeAddresses:
            - redis://*.*.*.*:6379
            - redis://*.*.*.*:6380
            - redis://*.*.*.*:6381
          password: ******
