### PR TITLE
解决springboot关闭时的超时提示：Failed to shut down 1 bean with phase value 0

### DIFF
--- a/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerInitializerConfiguration.java
+++ b/src/zoo/spring-boot/tio-websocket/src/main/java/org/tio/websocket/starter/TioWebSocketServerInitializerConfiguration.java
@@ -222,7 +222,9 @@ public class TioWebSocketServerInitializerConfiguration
 
     @Override
     public void stop() {
-
+    	if(isRunning()) {
+    		running = false;
+    	}
     }
 
     @Override
@@ -246,7 +248,8 @@ public class TioWebSocketServerInitializerConfiguration
 
     @Override
     public void stop(Runnable runnable) {
-
+    	stop();
+    	runnable.run();
     }
 
 }


### PR DESCRIPTION
解决springboot关闭时的超时提示：Failed to shut down 1 bean with phase value 0within timeout of 30000:[org.tio.websocket.starter.TioWebSocketServerInitializerConfiguration]